### PR TITLE
Fix/var bindings in tail

### DIFF
--- a/src/do.sjs
+++ b/src/do.sjs
@@ -60,12 +60,20 @@ macro $do {
             }()
         };
     }
-    case {_ {$x:ident = $y:expr $rest ... }} => {
+    case {_ {var $x:ident = $y:expr $rest ... }} => {
         return #{
             function() {
                 var $x = $y;
                 return $do { $rest ... }
             }()
+        };
+    }
+    case {_ {$a:ident <- $ma:expr var $($x:ident = $y:expr) (var) ... return $b:expr }} => {
+        return #{
+            $ma.map(function($a) {
+                $(var $x = $y;) ...
+                return $b;
+            });
         };
     }
     case {_ {$a:ident <- $ma:expr return $b:expr }} => {

--- a/src/do.sjs
+++ b/src/do.sjs
@@ -40,6 +40,17 @@
 
 */
 macro $do {
+    case {_ {$a:ident <- $do { $doBlock ... } var $($x:ident = $y:expr) (var) ... return $b:expr }} => {
+        return #{
+            function() {
+                var ma = $do { $doBlock ... }
+                return ma.map(function($a) {
+                    $(var $x = $y;) ...
+                    return $b
+                });
+            }()
+        };
+    }
     case {_ {$a:ident <- $do { $doBlock ... } return $b:expr }} => {
         return #{
             function() {
@@ -60,10 +71,10 @@ macro $do {
             }()
         };
     }
-    case {_ {var $x:ident = $y:expr $rest ... }} => {
+    case {_ {var $($x:ident = $y:expr) (var) ... $rest ... }} => {
         return #{
             function() {
-                var $x = $y;
+                $(var $x = $y;) ...
                 return $do { $rest ... }
             }()
         };
@@ -83,10 +94,26 @@ macro $do {
             });
         };
     }
+    case {_ {$a:ident <- $ma:expr var $($x:ident = $y:expr) (var) ... return if $rest ...}} => {
+        return #{
+            $ma.map(function($a) {
+                $(var $x = $y;) ...
+                $ifelsedo { if $rest ... }
+            });
+        };
+    }
     case {_ {$a:ident <- $ma:expr return if $rest ...}} => {
         return #{
             $ma.map(function($a) {
                 $ifelsedo { if $rest ... }
+            });
+        };
+    }
+    case {_ {$ma:expr var $($x:ident = $y:expr) (var) ... return $b:expr}} => {
+        return #{
+            $ma.map(function() {
+                $(var $x = $y;) ...
+                return $b;
             });
         };
     }
@@ -97,25 +124,71 @@ macro $do {
             });
         };
     }
-    case {_ {$a:ident <- $ma:expr if $e:expr return $left:expr else return $right:expr}} => {
+    case {_ {$a:ident <- $ma:expr var $($x:ident = $y:expr) (var) ... if $e:expr return $left:expr else return $right:expr }} => {
         return #{
             $ma.map(function($a) {
-                if ($e) { return $left }
-                else    { return $right }
+                $(var $x = $y;) ...
+                if ($e) {
+                    return $left
+                } else {
+                    return $right
+                }
+            });
+        };
+    }
+    case {_ {$a:ident <- $ma:expr if $e:expr return $left:expr else return $right:expr }} => {
+        return #{
+            $ma.map(function($a) {
+                if ($e) {
+                    return $left
+                } else {
+                    return $right
+                }
+            });
+        };
+    }
+    case {_ { $ma:expr var $($x:ident = $y:expr) (var) ... if $e:expr return $left:expr else return $right:expr }} => {
+        return #{
+            $ma.map(function() {
+                $(var $x = $y;) ...
+                if ($e) {
+                    return $left
+                } else {
+                    return $right
+                }
             });
         };
     }
     case {_ {$ma:expr if $e:expr return $left:expr else return $right:expr }} => {
         return #{
             $ma.map(function() {
-                if ($e) { return $left }
-                else    { return $right }
+                if ($e) {
+                    return $left
+                } else {
+                    return $right
+                }
+            });
+        };
+    }
+    case {_ {$a:ident <- $ma:expr var $($x:ident = $y:expr) (var) ... if $rest ... }} => {
+        return #{
+            $ma.chain(function($a) {
+                $(var $x = $y;) ...
+                $ifelsedo { if $rest ... }
             });
         };
     }
     case {_ {$a:ident <- $ma:expr if $rest ... }} => {
         return #{
             $ma.chain(function($a) {
+                $ifelsedo { if $rest ... }
+            });
+        };
+    }
+    case {_ {$ma:expr var $($x:ident = $y:expr) (var) ... if $rest ... }} => {
+        return #{
+            $ma.chain(function() {
+                $(var $x = $y;) ...
                 $ifelsedo { if $rest ... }
             });
         };
@@ -171,32 +244,43 @@ macro $do {
 macro $ifelsedo {
     case {_ { if $e:expr $do { $left ... } else return $right:expr }} => {
         return #{
-            if ($e) { return $do { $left ... } }
-            else    { return $right }
+            if ($e) {
+                return $do { $left ... }
+            } else {
+                return $right
+            }
         };
     }
     case {_ { if $e:expr return $left:expr else $do { $right ... } }} => {
         return #{
-            if ($e) { return $left }
-            else    { return $do { $right ... } }
+            if ($e) {
+                return $left
+            } else {
+                return $do { $right ... }
+            }
         };
     }
     case {_ { if $e:expr $do { $left ... } else $do { $right ... } }} => {
         return #{
-            if ($e) { return $do { $left ... } }
-            else    { return $do { $right ... } }
+            if ($e) {
+                return $do { $left ... }
+            } else {
+                return $do { $right ... }
+            }
         };
     }
     case {_ { if $e:expr return $left:expr else $rest ... }} => {
         return #{
-            if ($e) { return $left }
-            else $ifelsedo { $rest ... }
+            if ($e) {
+                return $left
+            } else $ifelsedo { $rest ... }
         };
     }
     case {_ { if $e:expr $do { $left ... } else $rest ... }} => {
         return #{
-            if ($e) { return $do { $left ... } }
-            else $ifelsedo { $rest ... }
+            if ($e) {
+                return $do { $left ... }
+            } else $ifelsedo { $rest ... }
         };
     }
 }

--- a/test/do.js
+++ b/test/do.js
@@ -25,6 +25,18 @@ exports.donotation = {
         },
         [String, String]
     ),
+    'supports var-bindings as tail': λ.check(
+        function(a, b) {
+            var sum = $do {
+                x <- Identity.of(a)
+                y <- Identity.of(b)
+                k = 'do'
+                return x + y + k
+            }
+            return sum.x === a + b + 'do';
+        },
+        [String, String]
+    ),
     'binding name is optional': λ.check(
         function(a, b) {
             var sum = $do {

--- a/test/do.js
+++ b/test/do.js
@@ -25,7 +25,7 @@ exports.donotation = {
         },
         [String, String]
     ),
-    'supports var-bindings as tail': λ.check(
+    'supports var-bindings as tail 1': λ.check(
         function(a, b) {
             var sum = $do {
                 x <- Identity.of(a)
@@ -37,16 +37,31 @@ exports.donotation = {
         },
         [String, String]
     ),
-    'supports multiple var-bindings as tail': λ.check(
+    'supports var-bindings as tail 2': λ.check(
+        function(a, b) {
+            var sum = $do {
+                x <- Identity.of(a)
+                y <- $do {
+                  y <- Identity.of(b)
+                  return y
+                }
+                var k = 'do'
+                return x + y + k
+            }
+            return sum.x === a + b + 'do';
+        },
+        [String, String]
+    ),
+    'supports var-bindings as tail 3': λ.check(
         function(a, b) {
             var sum = $do {
                 x <- Identity.of(a)
                 y <- Identity.of(b)
+                Identity.of(100)
                 var k = 'do'
-                var l = 'done'
-                return x + y + k + l
+                return x + y + k
             }
-            return sum.x === a + b + 'do' + 'done';
+            return sum.x === a + b + 'do';
         },
         [String, String]
     ),
@@ -67,7 +82,8 @@ exports.donotation = {
             var sum = $do {
                 x <- Identity.of(a)
                 y <- Identity.of(b)
-                if (x === a) return x + y else return ''
+                var z = y
+                if (x === a) return x + z else return ''
             }
             return sum.x === a + b;
         },
@@ -89,6 +105,7 @@ exports.donotation = {
             var sum = $do {
                 x <- Identity.of(a)
                 y <- Identity.of(b)
+                var z = y
                 if (x === a) $do {
                     z <- Identity.of(c)
                     return x + z
@@ -106,6 +123,7 @@ exports.donotation = {
             var sum = $do {
                 x <- Identity.of(a)
                 y <- Identity.of(b)
+                var z = y
                 return if (x === a) $do {
                     z <- Identity.of(c)
                     return x + z
@@ -165,6 +183,7 @@ exports.donotation = {
         function(a, b, c) {
             var sum = $do {
                 x <- Identity.of(a)
+                var z = 100
                 y <- $do {
                     z <- Identity.of(b)
                     return x + z

--- a/test/do.js
+++ b/test/do.js
@@ -17,7 +17,7 @@ exports.donotation = {
         function(a, b) {
             var sum = $do {
                 x <- Identity.of(a)
-                k = 'do'
+                var k = 'do'
                 y <- Identity.of(b)
                 return x + y + k
             }
@@ -30,10 +30,23 @@ exports.donotation = {
             var sum = $do {
                 x <- Identity.of(a)
                 y <- Identity.of(b)
-                k = 'do'
+                var k = 'do'
                 return x + y + k
             }
             return sum.x === a + b + 'do';
+        },
+        [String, String]
+    ),
+    'supports multiple var-bindings as tail': λ.check(
+        function(a, b) {
+            var sum = $do {
+                x <- Identity.of(a)
+                y <- Identity.of(b)
+                var k = 'do'
+                var l = 'done'
+                return x + y + k + l
+            }
+            return sum.x === a + b + 'do' + 'done';
         },
         [String, String]
     ),


### PR DESCRIPTION
Following up on @raimohanska's report of issue #5, this pull request adds some missing var-binding cases. Pretty mechanical work, and not very fun to write, so I hope I didn't miss anything (a fresh pair of eyes would be swell!).

However, this implementation requires each var-binding include the var prefix:

``` js
$do {
  a <- Identity.of(1)
  var b = a + 1
  var c = b * b
  return d
}
```
