### PR TITLE
Allows macros to be included with `sjs -m sweet-fantasies/src/*.sjs`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
                     dest: 'bin/src.sjs'
                 },
                 testMacros: {
-                    src: ['test/*.js', 'bin/src.sjs'],
+                    src: ['test/*.js'],
                     dest: 'bin/test.sjs'
                 }
             },
@@ -33,6 +33,7 @@ module.exports = function (grunt) {
             },
             sweet: {
                 all: {
+                    modules: ['./bin/src.sjs'],
                     src: 'bin/test.sjs',
                     dest: 'bin/test.js'
                 }
@@ -63,8 +64,13 @@ module.exports = function (grunt) {
 
     grunt.registerMultiTask('sweet', 'Run sweet.js', function() {
         var shell = require('shelljs'),
-            options = this.data;
-        shell.exec('sjs -o ' + options.dest + ' ' + options.src);
+            options = this.data,
+            modules = (options.modules || []).map(function(s){
+                        return '-m ' + JSON.stringify(s);
+                      }).join(' ');
+
+        console.log('sjs ' + modules + ' -o ' + options.dest + ' ' + options.src);
+        shell.exec('./node_modules/.bin/sjs ' + modules + ' -o ' + options.dest + ' ' + options.src);
     });
 
     grunt.registerTask('default', ['macro']);

--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
     "test": "grunt"
   },
   "devDependencies": {
-    "grunt-cli": "0.1.9",
+    "daggy": "0.0.1",
+    "fantasy-check": "0.x.x",
+    "fantasy-combinators": "0.x.x",
+    "fantasy-identities": "0.x.x",
+    "fantasy-options": "0.x.x",
     "grunt": "0.4.x",
-    "grunt-rigger": "0.5.x",
+    "grunt-cli": "0.1.9",
     "grunt-contrib-concat": "0.3.0",
     "grunt-contrib-jshint": "0.6.x",
     "grunt-contrib-nodeunit": "0.2.0",
+    "grunt-rigger": "0.5.x",
     "shelljs": "0.2.x",
-    "sweet.js": "0.2.x",
-    "fantasy-check": "0.x.x",
-    "fantasy-identities": "0.x.x",
-    "fantasy-options": "0.x.x",
-    "fantasy-combinators": "0.x.x"
+    "sweet.js": "0.2.x"
   }
 }

--- a/src/ap.sjs
+++ b/src/ap.sjs
@@ -19,3 +19,5 @@ macro $ap {
         }
     }
 }
+
+export $ap;

--- a/src/do.sjs
+++ b/src/do.sjs
@@ -284,3 +284,5 @@ macro $ifelsedo {
         };
     }
 }
+
+export $do

--- a/src/kleisli.sjs
+++ b/src/kleisli.sjs
@@ -47,3 +47,5 @@ macro $kleisli {
         }
     }
 }
+
+export $kleisli;

--- a/src/semigroup.sjs
+++ b/src/semigroup.sjs
@@ -10,3 +10,5 @@ macro $semigroup {
         };
     }
 }
+
+export $semigroup;


### PR DESCRIPTION
This allows Sweet.js to use the macros without having to concatenate things, and works with Sweet.js from 0.2.x onwards.
