### PR TITLE
Updates macros for Sweet.js 0.6.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
                     dest: 'bin/src.sjs'
                 },
                 testMacros: {
-                    src: ['test/*.js', 'bin/src.sjs'],
+                    src: ['test/*.js'],
                     dest: 'bin/test.sjs'
                 }
             },
@@ -33,6 +33,7 @@ module.exports = function (grunt) {
             },
             sweet: {
                 all: {
+                    modules: ['./bin/src.sjs'],
                     src: 'bin/test.sjs',
                     dest: 'bin/test.js'
                 }
@@ -63,8 +64,13 @@ module.exports = function (grunt) {
 
     grunt.registerMultiTask('sweet', 'Run sweet.js', function() {
         var shell = require('shelljs'),
-            options = this.data;
-        shell.exec('sjs -o ' + options.dest + ' ' + options.src);
+            options = this.data,
+            modules = (options.modules || []).map(function(s){
+                        return '-m ' + JSON.stringify(s);
+                      }).join(' ');
+
+        console.log('sjs ' + modules + ' -o ' + options.dest + ' ' + options.src);
+        shell.exec('./node_modules/.bin/sjs ' + modules + ' -o ' + options.dest + ' ' + options.src);
     });
 
     grunt.registerTask('default', ['macro']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,8 +69,8 @@ module.exports = function (grunt) {
                         return '-m ' + JSON.stringify(s);
                       }).join(' ');
 
-        console.log('sjs ' + modules + ' -o ' + options.dest + ' ' + options.src);
-        shell.exec('./node_modules/.bin/sjs ' + modules + ' -o ' + options.dest + ' ' + options.src);
+        console.log('sjs -r' + modules + ' -o ' + options.dest + ' ' + options.src);
+        shell.exec('./node_modules/.bin/sjs -r ' + modules + ' -o ' + options.dest + ' ' + options.src);
     });
 
     grunt.registerTask('default', ['macro']);

--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
     "test": "grunt"
   },
   "devDependencies": {
-    "grunt-cli": "0.1.9",
+    "daggy": "0.0.1",
+    "fantasy-check": "0.x.x",
+    "fantasy-combinators": "0.x.x",
+    "fantasy-identities": "0.x.x",
+    "fantasy-options": "0.x.x",
     "grunt": "0.4.x",
-    "grunt-rigger": "0.5.x",
+    "grunt-cli": "0.1.9",
     "grunt-contrib-concat": "0.3.0",
     "grunt-contrib-jshint": "0.6.x",
     "grunt-contrib-nodeunit": "0.2.0",
+    "grunt-rigger": "0.5.x",
     "shelljs": "0.2.x",
-    "sweet.js": "0.2.x",
-    "fantasy-check": "0.x.x",
-    "fantasy-identities": "0.x.x",
-    "fantasy-options": "0.x.x",
-    "fantasy-combinators": "0.x.x"
+    "sweet.js": "0.2.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "grunt-contrib-nodeunit": "0.2.0",
     "grunt-rigger": "0.5.x",
     "shelljs": "0.2.x",
-    "sweet.js": "^0.6.0"
+    "sweet.js": "~0.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "grunt-contrib-nodeunit": "0.2.0",
     "grunt-rigger": "0.5.x",
     "shelljs": "0.2.x",
-    "sweet.js": "0.2.x"
+    "sweet.js": "^0.6.0"
   }
 }

--- a/src/ap.sjs
+++ b/src/ap.sjs
@@ -19,3 +19,5 @@ macro $ap {
         }
     }
 }
+
+export $ap;

--- a/src/do.sjs
+++ b/src/do.sjs
@@ -44,22 +44,46 @@ macro $do {
 }
 
 macroclass binding {
-  pattern { $id:ident <- $op:expr; } 
-  pattern { $id:ident <- $op:expr  }
-  pattern { $op:expr; } where ($id = #{ _it })
-  pattern { $op:expr  } where ($id = #{ _it })
+  pattern {
+    rule { $id:ident <- $op:expr; }
+  } 
+  pattern {
+    rule { $id:ident <- $op:expr }
+  }
+  pattern {
+    rule { $op:expr; }
+    with $id = #{ _it }
+  }
+  pattern {
+    rule { $op:expr }
+    with $id = #{ _it }
+  }
 }
 
 macroclass pureBinding {
-  pattern { $id:ident <- return $value:expr; }
-  pattern { $id:ident <- return $value:expr }
-  pattern { return $value:expr; } where ($id = #{ _it })
-  pattern { return $value:expr  } where ($id = #{ _it })
+  pattern {
+    rule { $id:ident <- return $value:expr; }
+  }
+  pattern {
+    rule { $id:ident <- return $value:expr }
+  }
+  pattern {
+    rule { return $value:expr; }
+    with $id = #{ _it }
+  }
+  pattern {
+    rule { return $value:expr  }
+    with $id = #{ _it }
+  }
 }
 
 macroclass vardecl {
-  pattern { var $id:ident = $value:expr; }
-  pattern { var $id:ident = $value:expr  }
+  pattern {
+    rule { var $id:ident = $value:expr; }
+  }
+  pattern {
+    rule { var $id:ident = $value:expr }
+  }
 }
 
 macro returnableExpr {
@@ -68,8 +92,12 @@ macro returnableExpr {
 }
 
 macroclass ifelsedo {
-  pattern { if ( $test:expr ) $consequent:returnableExpr else $alternative:returnableExpr; }
-  pattern { if ( $test:expr ) $consequent:returnableExpr else $alternative:returnableExpr }
+  pattern {
+    rule { if ( $test:expr ) $consequent:returnableExpr else $alternative:returnableExpr; }
+  }
+  pattern {
+    rule { if ( $test:expr ) $consequent:returnableExpr else $alternative:returnableExpr }
+  }
 }
 
 macro _do {

--- a/src/do.sjs
+++ b/src/do.sjs
@@ -74,16 +74,16 @@ macroclass ifelsedo {
 
 macro _do {
   // -- Base cases -----------------------------------------------------
-  rule {{ $op:expr }} => {
+  rule {{ $op:expr ; ... }} => {
     return $op
   }
-  rule { $type { $op:expr }} => {
+  rule { $type { $op:expr ; ... }} => {
     return $op
   }
-  rule { $type { return $a:expr }} => {
+  rule { $type { return $a:expr ; ... }} => {
     return $type($a)
   }
-  rule { $type { return if ( $a:expr ) $b:expr else $c:expr }} => {
+  rule { $type { return if ( $a:expr ) $b:expr ; ... else $c:expr ; ... }} => {
     if ($a) {
       _do $type { return $b }
     } else {

--- a/src/do.sjs
+++ b/src/do.sjs
@@ -81,7 +81,7 @@ macro _do {
     return $op
   }
   rule { $type { return $a:expr }} => {
-    return $type.of($a)
+    return $type($a)
   }
   rule { $type { return if ( $a:expr ) $b:expr else $c:expr }} => {
     if ($a) {
@@ -108,7 +108,7 @@ macro _do {
   }
 
   rule { $type { $a:pureBinding $rest ... }} => {
-    return $type.of($a$value).chain(function($a$id) {
+    return $type($a$value).chain(function($a$id) {
       _do $type { $rest ... }
     })
   }

--- a/src/do.sjs
+++ b/src/do.sjs
@@ -284,3 +284,5 @@ macro $ifelsedo {
         };
     }
 }
+
+export $do

--- a/src/do.sjs
+++ b/src/do.sjs
@@ -22,7 +22,7 @@
 
    $do {
      x <- foo
-     k = 10
+     var k = 10
      y <- bar(x)
      z <- baz
      return x * y * z * k

--- a/src/kleisli.sjs
+++ b/src/kleisli.sjs
@@ -20,7 +20,7 @@
 
 */
 macro $kleisli {
-    case {_ ($x:expr >=> $e ...) > $y:expr $rest ... } => {
+    case {_ ($x >=> $e ...) > $y:expr $rest ... } => {
         return #{
             function(a) {
                 return $x(a) $kleisli {$e ...}
@@ -28,7 +28,7 @@ macro $kleisli {
             $rest ...
         }
     }
-    case {_ ($x:expr >=> $e ...) $rest ... } => {
+    case {_ ($x >=> $e ...) $rest ... } => {
         return #{
             function(a) {
                 return $x(a) $kleisli {$e ...}
@@ -48,4 +48,4 @@ macro $kleisli {
     }
 }
 
-export $kleisli;
+export $kleisli

--- a/src/kleisli.sjs
+++ b/src/kleisli.sjs
@@ -47,3 +47,5 @@ macro $kleisli {
         }
     }
 }
+
+export $kleisli;

--- a/src/semigroup.sjs
+++ b/src/semigroup.sjs
@@ -10,3 +10,5 @@ macro $semigroup {
         };
     }
 }
+
+export $semigroup;

--- a/test/do.js
+++ b/test/do.js
@@ -227,5 +227,49 @@ exports.donotation = {
             return sum.x === a + b
         },
         [String, String]
+    ),
+    'supports semicolons to separate statements (return)': λ.check(
+        function(a, b) {
+            var sum = $do {
+                x <- Identity.of(a);
+                y <- return b;
+                return x + y;
+            }
+            return sum.x === a + b
+        },
+        [String, String]
+    ),
+    'supports semicolons to separate statements (naked op)': λ.check(
+        function(a, b) {
+            var sum = $do {
+                x <- Identity.of(a);
+                y <- return b;
+                Identity.of(x + y);
+            }
+            return sum.x === a + b
+        },
+        [String, String]
+    ),
+    'supports semicolons to separate statements (only naked op)': λ.check(
+        function(a, b) {
+            var sum = $do {
+                Identity.of(a + b);
+            }
+            return sum.x === a + b
+        },
+        [String, String]
+    ),
+    'supports semicolons to separate statements (if/else)': λ.check(
+        function(a, b) {
+            var sum = $do {
+                x <- Identity.of(a);
+                y <- return b;
+                return if (x > y) x + y;
+                       else       y + x;
+            }
+            return sum.x === ((a > b)? a + b : b + a)
+        },
+        [String, String]
     )
+  
 };

--- a/test/do.js
+++ b/test/do.js
@@ -205,5 +205,27 @@ exports.donotation = {
             return sum.x === a + b;
         },
         [String, String]
+    ),
+    'supports multiple returns': λ.check(
+        function(a, b, c) {
+            var sum = $do {
+                x <- Identity.of(a)
+                return b
+                return c
+            }
+            return sum.x === c
+        },
+        [String, String, String]
+    ),
+    'supports return in a binding expression': λ.check(
+        function(a, b) {
+            var sum = $do {
+                x <- Identity.of(a)
+                y <- return b
+                return x + y
+            }
+            return sum.x === a + b
+        },
+        [String, String]
     )
 };

--- a/test/do.js
+++ b/test/do.js
@@ -8,7 +8,7 @@ exports.donotation = {
                 x <- Identity.of(a)
                 y <- Identity.of(b)
                 return x + y
-            }
+            }.map(function(a){ return a });
             return sum.x === a + b;
         },
         [String, String]
@@ -194,5 +194,16 @@ exports.donotation = {
             return sum.x === a + a + b + c;
         },
         [String, String, String]
+    ),
+    'supports an action as the last expression': λ.check(
+        function(a, b) {
+            var sum = $do {
+                x <- Identity.of(a)
+                y <- Identity.of(b)
+                Identity.of(x + y)
+            }
+            return sum.x === a + b;
+        },
+        [String, String]
     )
 };

--- a/test/kleisli.js
+++ b/test/kleisli.js
@@ -8,14 +8,14 @@ function identityM(x) {
 exports.kleisli = {
     'chain values': λ.check(
         function(a) {
-            var s = $kleisli (Identity.of >=> identityM) > a;
+            var s = $kleisli ((Identity.of) >=> identityM) > a;
             return s.x === a;
         },
         [String, String]
     ),
     'deferred chain values': λ.check(
         function(a) {
-            var s = $kleisli (Identity.of >=> identityM),
+            var s = $kleisli ((Identity.of) >=> identityM),
                 x = s(a);
             return x.x === a;
         },


### PR DESCRIPTION
This addresses (https://github.com/puffnfresh/sweet-fantasies/issues/8), it's mainly a complete rewrite of the `do` notation macro. Other macros should probably be dropped now and rewritten using Sweet.js's custom operators (http://sweetjs.org/doc/main/sweet.html#custom-operators), as they make more sense as infix.

This patch also supports having a naked action as the last expression, so:

``` js
var a = $do {
  x <- f()
  y <- g()
  h(x, y)
}
```

Works and gets desugared as expected:

``` js
var a = (function() {
  return f().chain(function(x) {
    return g().chain(function(y) {
      return h(x, y)
    })
  })
}())
```

A couple of things worth noting about this patch:
1. Actions that aren't bound to an explicit identifier gets bound to `_it`. This was mainly for simplicity dealing with all the cases, so: `$do { a; b }` gets desugared to `a.chain(_it => b)`. I'm unsure if this is much of a problem, though this does introduce an implicit new binding in the scope, which might lead to some awkward things(?)
2. Do blocks are wrapped in a immediately forced thunk. This was again mainly for simplicity with dealing with variable bindings. 
3. The patch makes use of an experimental feature in Sweet.js 0.6.x (http://sweetjs.org/doc/main/sweet.html#custom-pattern-classes-experimental) to abstract over some patterns. This is mainly to allow constructs to be optionally separated with a semicolon, I'm unsure to which extent this is actually useful.
4. This patch does not support multiple returns. I'm unsure if this was supported before? It should be reasonably doable though, and I'll give it a go once I've got a little bit more of time.
